### PR TITLE
Update book_rest.js - ability for other models to use this adapter

### DIFF
--- a/app/lib/alloy/sync/book_rest.js
+++ b/app/lib/alloy/sync/book_rest.js
@@ -8,7 +8,11 @@ module.exports.sync = function(method, model, options) {
 
 	var payload = model.toJSON();
 	var error;
-
+	
+	if(typeof(model.config.adapter.base_url) != 'undefined'){
+		BASE_URL = model.config.adapter.base_url; 
+		// this enables other models using the same adapter to work, otherwise the BASE_URL variable persists
+	}
 	switch(method) {
 
 		// This case is called by the Model.fetch and Collection.fetch methods to retrieve data.


### PR DESCRIPTION
the code at line 111 causes the BASE_URL to persist even if different models (with different base urls) use the same sync adapter, so i added code in the sync method to override BASE_URL with the adapter's config.base_url.
